### PR TITLE
Local Cursor, down scaling and "on demand" mode

### DIFF
--- a/RemoteViewing.Example/MainForm.Designer.cs
+++ b/RemoteViewing.Example/MainForm.Designer.cs
@@ -166,7 +166,9 @@
             this.vncControl.AllowClipboardSharingToServer = true;
             this.vncControl.AllowInput = true;
             this.vncControl.AllowRemoteCursor = true;
-            this.vncControl.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.vncControl.HideLocalCursor = false;
+            //this.vncControl.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.vncControl.Dock = System.Windows.Forms.DockStyle.Fill;
             this.vncControl.BackColor = System.Drawing.Color.Black;
             vncClient1.MaxUpdateRate = 15D;
             vncClient1.UserData = null;

--- a/RemoteViewing.Tests/Properties/AssemblyInfo.cs
+++ b/RemoteViewing.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RemoteViewing.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RemoteViewing.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("443275f4-da96-4015-ba5b-c1ebe908edfa")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/RemoteViewing.Tests/RemoteViewing.Tests.csproj
+++ b/RemoteViewing.Tests/RemoteViewing.Tests.csproj
@@ -1,0 +1,64 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{443275F4-DA96-4015-BA5B-C1EBE908EDFA}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>RemoteViewing.Tests</RootNamespace>
+    <AssemblyName>RemoteViewing.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="VncClientTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RemoteViewing.Windows.Forms\RemoteViewing.Windows.Forms.csproj">
+      <Project>{4fe8ac04-3825-4cfc-8f1d-4c4064fb5727}</Project>
+      <Name>RemoteViewing.Windows.Forms</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\RemoteViewing\RemoteViewing.csproj">
+      <Project>{89569346-2c71-4a85-99b9-d3eb71fde87a}</Project>
+      <Name>RemoteViewing</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/RemoteViewing.Tests/VncClientTests.cs
+++ b/RemoteViewing.Tests/VncClientTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using RemoteViewing.Vnc;
+using RemoteViewing.Windows.Forms;
+
+namespace RemoteViewing.Tests
+{
+    [TestFixture]
+    internal class VncClientTests
+    {
+        public const string Address = "192.168.0.23";
+
+        [Test]
+        public void Test()
+        {
+            using (var vncClient = new VncClient())
+            {
+                vncClient.Connect(Address, 5900,
+                    new VncClientConnectOptions {OnDemandMode = true, PasswordRequiredCallback = c => "100".ToArray()});
+
+                var width = 200;
+                var height = 300;
+                var copy =  vncClient.GetFramebuffer(100, 100, width, height);
+                var bitmap = this.CreateBitmap(copy, width, height);
+                bitmap.Save(@"C:\TestOutput\Test.bmp", ImageFormat.Bmp);
+                Assert.AreNotEqual(Color.Black.ToArgb(), bitmap.GetPixel(10, 10).ToArgb());
+               
+            }
+
+        }
+
+        private Bitmap CreateBitmap(Action<IntPtr, int> copyAction, int width, int heigth)
+        {
+            var bitmap = new Bitmap(width, heigth);
+            var winformsRect = new Rectangle(0, 0, bitmap.Width, bitmap.Height);
+            var data = bitmap.LockBits(winformsRect, ImageLockMode.WriteOnly, PixelFormat.Format32bppRgb);
+            try
+            {
+                copyAction(data.Scan0, data.Stride);
+            }
+            finally
+            {
+                bitmap.UnlockBits(data);
+            }
+            return bitmap;
+        }
+    }
+}

--- a/RemoteViewing.Tests/packages.config
+++ b/RemoteViewing.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.6.1" targetFramework="net452" />
+</packages>

--- a/RemoteViewing.Windows.Forms/VncBitmap.cs
+++ b/RemoteViewing.Windows.Forms/VncBitmap.cs
@@ -107,36 +107,16 @@ namespace RemoteViewing.Windows.Forms
             int targetX,
             int targetY)
         {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
             if (target == null)
             {
                 throw new ArgumentNullException(nameof(target));
-            }
-
-            if (sourceRectangle.IsEmpty)
-            {
-                return;
             }
 
             var winformsRect = new Rectangle(targetX, targetY, sourceRectangle.Width, sourceRectangle.Height);
             var data = target.LockBits(winformsRect, ImageLockMode.WriteOnly, PixelFormat.Format32bppRgb);
             try
             {
-                fixed (byte* framebufferData = source.GetBuffer())
-                {
-                    VncPixelFormat.Copy(
-                        (IntPtr)framebufferData,
-                        source.Stride,
-                        source.PixelFormat,
-                        sourceRectangle,
-                        data.Scan0,
-                        data.Stride,
-                        new VncPixelFormat());
-                }
+                VncPixelFormat.CopyFromFramebuffer(source, sourceRectangle, data.Scan0, data.Stride, targetX, targetY);
             }
             finally
             {

--- a/RemoteViewing.sln
+++ b/RemoteViewing.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.10
+VisualStudioVersion = 15.0.26430.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RemoteViewing", "RemoteViewing\RemoteViewing.csproj", "{89569346-2C71-4A85-99B9-D3EB71FDE87A}"
 EndProject
@@ -14,6 +14,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RemoteViewing.NoVncExample", "RemoteViewing.NoVncExample\RemoteViewing.NoVncExample.csproj", "{59A4B4EA-3B07-4D92-ACD6-A2D80C08D823}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RemoteViewing.AspNetCore", "RemoteViewing.AspNetCore\RemoteViewing.AspNetCore.csproj", "{4E38F24D-C09B-4739-BD9E-E97FF70B93D3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RemoteViewing.Tests", "RemoteViewing.Tests\RemoteViewing.Tests.csproj", "{443275F4-DA96-4015-BA5B-C1EBE908EDFA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -93,6 +95,18 @@ Global
 		{4E38F24D-C09B-4739-BD9E-E97FF70B93D3}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{4E38F24D-C09B-4739-BD9E-E97FF70B93D3}.Release|x86.ActiveCfg = Release|Any CPU
 		{4E38F24D-C09B-4739-BD9E-E97FF70B93D3}.Release|x86.Build.0 = Release|Any CPU
+		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Debug|x86.Build.0 = Debug|Any CPU
+		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Release|x86.ActiveCfg = Release|Any CPU
+		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RemoteViewing.sln
+++ b/RemoteViewing.sln
@@ -15,8 +15,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RemoteViewing.NoVncExample"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RemoteViewing.AspNetCore", "RemoteViewing.AspNetCore\RemoteViewing.AspNetCore.csproj", "{4E38F24D-C09B-4739-BD9E-E97FF70B93D3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RemoteViewing.Tests", "RemoteViewing.Tests\RemoteViewing.Tests.csproj", "{443275F4-DA96-4015-BA5B-C1EBE908EDFA}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -95,18 +93,6 @@ Global
 		{4E38F24D-C09B-4739-BD9E-E97FF70B93D3}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{4E38F24D-C09B-4739-BD9E-E97FF70B93D3}.Release|x86.ActiveCfg = Release|Any CPU
 		{4E38F24D-C09B-4739-BD9E-E97FF70B93D3}.Release|x86.Build.0 = Release|Any CPU
-		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Debug|x86.Build.0 = Debug|Any CPU
-		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Release|x86.ActiveCfg = Release|Any CPU
-		{443275F4-DA96-4015-BA5B-C1EBE908EDFA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RemoteViewing/Vnc/VncClient.Framebuffer.cs
+++ b/RemoteViewing/Vnc/VncClient.Framebuffer.cs
@@ -54,13 +54,13 @@ namespace RemoteViewing.Vnc
             return VncUtility.AllocateScratch(bytes, ref this.framebufferScratch);
         }
 
-        private void HandleFramebufferUpdate()
+        private bool HandleFramebufferUpdate()
         {
             this.c.ReceiveByte(); // padding
 
             var numRects = this.c.ReceiveUInt16BE();
             var rects = new List<VncRectangle>();
-
+            var encoding = VncEncoding.DesktopSize;
             for (int i = 0; i < numRects; i++)
             {
                 var r = this.c.ReceiveRectangle();
@@ -72,7 +72,7 @@ namespace RemoteViewing.Vnc
                 var inRange = w <= fbW && h <= fbH && x <= fbW - w && y <= fbH - h;
                 byte[] pixels;
 
-                var encoding = (VncEncoding)this.c.ReceiveUInt32BE();
+                encoding = (VncEncoding)this.c.ReceiveUInt32BE();
                 switch (encoding)
                 {
                     case VncEncoding.Hextile: // KVM seems to avoid this now that I support Zlib.
@@ -278,6 +278,8 @@ namespace RemoteViewing.Vnc
             {
                 this.OnFramebufferChanged(new FramebufferChangedEventArgs(rects));
             }
+
+            return encoding != VncEncoding.DesktopSize;
         }
     }
 }

--- a/RemoteViewing/Vnc/VncClientConnectOptions.cs
+++ b/RemoteViewing/Vnc/VncClientConnectOptions.cs
@@ -68,6 +68,12 @@ namespace RemoteViewing.Vnc
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether a polling thread should be started and frame buffer updates
+        /// are published via events or the frame buffer updates are triggered manually (on demand) by calling the respective functions.
+        /// </summary>
+        public bool OnDemandMode { get; set; }
+
+        /// <summary>
         /// Gets or sets a callback which is called when a password is required and
         /// <see cref="VncClientConnectOptions.Password"/> is <see langword="null"/>.
         /// </summary>

--- a/RemoteViewing/Vnc/VncPixelFormat.cs
+++ b/RemoteViewing/Vnc/VncPixelFormat.cs
@@ -339,6 +339,46 @@ namespace RemoteViewing.Vnc
             }
         }
 
+        /// <summary>
+        /// Copies a region of the framebuffer into a bitmap.
+        /// </summary>
+        /// <param name="source">The framebuffer to read.</param>
+        /// <param name="sourceRectangle">The framebuffer region to copy.</param>
+        /// <param name="scan0">The bitmap buffer start address</param>
+        /// <param name="stride">The bitmap width stride</param>
+        /// <param name="targetX">The leftmost X coordinate of the bitmap to draw to.</param>
+        /// <param name="targetY">The topmost Y coordinate of the bitmap to draw to.</param>
+        public static unsafe void CopyFromFramebuffer(
+            VncFramebuffer source,
+            VncRectangle sourceRectangle,
+            IntPtr scan0,
+            int stride,
+            int targetX,
+            int targetY)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (sourceRectangle.IsEmpty)
+            {
+                return;
+            }
+
+            fixed (byte* framebufferData = source.GetBuffer())
+            {
+                VncPixelFormat.Copy(
+                    (IntPtr) framebufferData,
+                    source.Stride,
+                    source.PixelFormat,
+                    sourceRectangle,
+                    scan0,
+                    stride,
+                    new VncPixelFormat());
+            }
+        }
+
         /// <inheritdoc />
         public override bool Equals(object obj)
         {


### PR DESCRIPTION
Hi,
thats my first pull request. I've added these features:
- added possibility to show local cursor when remote cursor is activated
   -> In the demo application, the local and the remote cursor are shown now. But i've added a property and the default behavior is like it was before (not showing the local cursor)
- added down scaling functionality for windows forms control 
   -> When you resize the demo application, the remote view shrinks automatically according to the size of the window
- added OnDemandMode option and GetFramebuffer function
  -> disables the poll thread and provides the possibility to get framebuffer updates in a synchronous way
- some additional changes to maximize reuse and flexibility


Best regards,
Tom