### PR TITLE
Additional flexibility in subclassing/mocking VncServerSession

### DIFF
--- a/RemoteViewing.AspNetCore/VncHandler.cs
+++ b/RemoteViewing.AspNetCore/VncHandler.cs
@@ -11,7 +11,7 @@ namespace RemoteViewing.AspNetCore
     /// <summary>
     /// Handles noVNC connections.
     /// </summary>
-    public class VncHandler
+    public class VncHandler<T> where T : VncServerSession, new()
     {
         /// <summary>
         /// This event will be reset when the conection with the client is lost, either because the client logged
@@ -47,7 +47,9 @@ namespace RemoteViewing.AspNetCore
 
             this.VncContext = vncContext;
             this.Socket = socket;
-            this.Vnc = new VncServerSession(vncContext.PasswordChallenge ?? new VncPasswordChallenge(), vncContext.Logger);
+            this.Vnc = new T();
+            this.Vnc.PasswordChallenge = vncContext.PasswordChallenge ?? new VncPasswordChallenge();
+            this.Vnc.Logger = vncContext.Logger;
 
             if (vncContext.CreateFramebufferCache != null)
             {
@@ -85,7 +87,7 @@ namespace RemoteViewing.AspNetCore
         /// <summary>
         /// Gets the current <see cref="VncServerSession"/>.
         /// </summary>
-        public VncServerSession Vnc
+        public T Vnc
         {
             get;
             private set;

--- a/RemoteViewing.AspNetCore/VncMiddleware.cs
+++ b/RemoteViewing.AspNetCore/VncMiddleware.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using RemoteViewing.Vnc.Server;
 using System;
 using System.Threading.Tasks;
 
@@ -7,7 +8,7 @@ namespace RemoteViewing.AspNetCore
     /// <summary>
     /// The middleware which handles noVNC connections.
     /// </summary>
-    public class VncMiddleware
+    public class VncMiddleware<T> where T : VncServerSession, new()
     {
         private readonly RequestDelegate next;
         private Func<HttpContext, VncContext> vncContextFactory;
@@ -59,7 +60,7 @@ namespace RemoteViewing.AspNetCore
             {
                 var socket = await context.WebSockets.AcceptWebSocketAsync("binary").ConfigureAwait(false);
 
-                VncHandler sockethandler = new VncHandler(socket, vncContext);
+                VncHandler<T> sockethandler = new VncHandler<T>(socket, vncContext);
                 await sockethandler.Listen().ConfigureAwait(false);
             }
         }

--- a/RemoteViewing.AspNetCore/VncMiddlewareExtensions.cs
+++ b/RemoteViewing.AspNetCore/VncMiddlewareExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using RemoteViewing.Vnc.Server;
 using System;
 
 namespace RemoteViewing.AspNetCore
@@ -31,7 +32,7 @@ namespace RemoteViewing.AspNetCore
         {
             return app
                 .UseWebSockets()
-                .Map(path, a => a.UseMiddleware<VncMiddleware>(vncContextFactory));
+                .Map(path, a => a.UseMiddleware<VncMiddleware<VncServerSession>>(vncContextFactory));
         }
     }
 }

--- a/RemoteViewing/Vnc/Server/IVncFramebufferCache.cs
+++ b/RemoteViewing/Vnc/Server/IVncFramebufferCache.cs
@@ -50,6 +50,6 @@ namespace RemoteViewing.Vnc.Server
         /// <see langword="true"/> if the operation completed successfully; otherwise,
         /// <see langword="false"/>.
         /// </returns>
-        bool RespondToUpdateRequest(VncServerSession session);
+        bool RespondToUpdateRequest(IVncServerSession session);
     }
 }

--- a/RemoteViewing/Vnc/Server/IVncServerSession.cs
+++ b/RemoteViewing/Vnc/Server/IVncServerSession.cs
@@ -1,0 +1,62 @@
+﻿namespace RemoteViewing.Vnc.Server
+{
+    public interface IVncServerSession
+    {
+        /// <summary>
+        /// Gets information about the client's most recent framebuffer update request.
+        /// This may be <see langword="null"/> if the client has no framebuffer request queued.
+        /// </summary>
+        FramebufferUpdateRequest FramebufferUpdateRequest { get; }
+
+        /// <summary>
+        /// Gets a lock which should be used before performing any framebuffer updates.
+        /// </summary>
+        object FramebufferUpdateRequestLock { get; }
+
+        /// <summary>
+        /// Begins a manual framebuffer update.
+        /// </summary>
+        /// <remarks>
+        /// Do not call this method without holding <see cref="IVncServerSession.FramebufferUpdateRequestLock"/>.
+        /// </remarks>
+        void FramebufferManualBeginUpdate();
+
+        /// <summary>
+        /// Queues an update for the specified region.
+        /// </summary>
+        /// <remarks>
+        /// Do not call this method without holding <see cref="IVncServerSession.FramebufferUpdateRequestLock"/>.
+        /// </remarks>
+        /// <param name="region">The region to invalidate.</param>
+        void FramebufferManualInvalidate(VncRectangle region);
+
+        /// <summary>
+        /// Queues an update for each of the specified regions.
+        /// </summary>
+        /// <remarks>
+        /// Do not call this method without holding <see cref="IVncServerSession.FramebufferUpdateRequestLock"/>.
+        /// </remarks>
+        /// <param name="regions">The regions to invalidate.</param>
+        void FramebufferManualInvalidate(VncRectangle[] regions);
+
+        /// <summary>
+        /// Queues an update for the entire framebuffer.
+        /// </summary>
+        /// <remarks>
+        /// Do not call this method without holding <see cref="VncServerSession.FramebufferUpdateRequestLock"/>.
+        /// </remarks>
+        void FramebufferManualInvalidateAll();
+
+        /// <summary>
+        /// Completes a manual framebuffer update.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true"/> if the operation completed successfully; otherwise,
+        /// <see langword="false"/>.
+        /// </returns>
+        /// <remarks>
+        /// Do not call this method without holding <see cref="VncServerSession.FramebufferUpdateRequestLock"/>.
+        /// </remarks>
+        bool FramebufferManualEndUpdate();
+    }
+}

--- a/RemoteViewing/Vnc/Server/VncFramebufferCache.cs
+++ b/RemoteViewing/Vnc/Server/VncFramebufferCache.cs
@@ -92,7 +92,7 @@ namespace RemoteViewing.Vnc.Server
         /// <see langword="true"/> if the operation completed successfully; otherwise,
         /// <see langword="false"/>.
         /// </returns>
-        public unsafe bool RespondToUpdateRequest(VncServerSession session)
+        public unsafe bool RespondToUpdateRequest(IVncServerSession session)
         {
             VncRectangle subregion = default(VncRectangle);
 


### PR DESCRIPTION
* Support passing a custom subclass of `VncServerSession` in the ASP.NET Core `VncMiddleware`.
* Create a `IVncServerSession` interface, so that `VncFramebufferCache` can be unit-tested easily.