### PR TITLE
Handle a TaskCancelledException in VncServerSession. 

### DIFF
--- a/RemoteViewing.AspNetCore/WebSocketStream.cs
+++ b/RemoteViewing.AspNetCore/WebSocketStream.cs
@@ -87,7 +87,7 @@ namespace RemoteViewing.AspNetCore
         public override int Read(byte[] buffer, int offset, int count)
         {
             ArraySegment<byte> segment = new ArraySegment<byte>(buffer, offset, count);
-            var result = this.WebSocket.ReceiveAsync(segment, CancellationToken.None).Result;
+            var result = this.WebSocket.ReceiveAsync(segment, CancellationToken.None).GetAwaiter().GetResult();
             return result.Count;
         }
 

--- a/RemoteViewing/Vnc/Server/VncServerSession.cs
+++ b/RemoteViewing/Vnc/Server/VncServerSession.cs
@@ -32,6 +32,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace RemoteViewing.Vnc.Server
 {
@@ -723,6 +724,9 @@ namespace RemoteViewing.Vnc.Server
             {
             }
             catch (VncException)
+            {
+            }
+            catch (TaskCanceledException)
             {
             }
 


### PR DESCRIPTION
This can happen when the connection is an ASP.NET Core WebSocket and the server is shutting down