### PR TITLE
Move VncLogger (which wraps around ILogger) to the RemoteViewing

### DIFF
--- a/RemoteViewing/RemoteViewing.csproj
+++ b/RemoteViewing/RemoteViewing.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="System.Memory" Version="4.5.0" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/RemoteViewing/VncLogger.cs
+++ b/RemoteViewing/VncLogger.cs
@@ -31,7 +31,7 @@ using RemoteViewing.Logging;
 using System;
 using VncLogLevel = RemoteViewing.Logging.LogLevel;
 
-namespace RemoteViewing.AspNetCore
+namespace RemoteViewing
 {
     /// <summary>
     /// A default implementation of the <see cref="ILog"/> interface which wraps around the ASP.NET Core <see cref="ILogger"/> interface.
@@ -46,6 +46,7 @@ namespace RemoteViewing.AspNetCore
         /// <param name="logger">
         /// The ASP.NET Core logger to use when processing log messages.
         /// </param>
+        [CLSCompliant(false)]
         public VncLogger(ILogger logger)
         {
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));


### PR DESCRIPTION
Other users may find it useful, and it comes at the cost of a tiny dependency.