### PR TITLE
Update license information

### DIFF
--- a/RemoteViewing.AspNetCore/RemoteViewing.AspNetCore.csproj
+++ b/RemoteViewing.AspNetCore/RemoteViewing.AspNetCore.csproj
@@ -9,12 +9,15 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Quamotion.RemoteViewing.AspNetCore</PackageId>
     <PackageProjectUrl>https://github.com/qmfrederik/remoteviewing/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/qmfrederik/remoteviewing/blob/master/License.txt</PackageLicenseUrl>
     <PackageTags>VNC RFB remote desktop client server Hextile Copyrect Zlib asp aspnet aspnetcore noVNC</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <CodeAnalysisRuleSet>..\RemoteViewing.ruleset</CodeAnalysisRuleSet>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\RemoteViewing\RemoteViewing.csproj" />

--- a/RemoteViewing.Windows.Forms/RemoteViewing.Windows.Forms.csproj
+++ b/RemoteViewing.Windows.Forms/RemoteViewing.Windows.Forms.csproj
@@ -12,12 +12,14 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Quamotion.RemoteViewing.Windows.Forms</PackageId>
     <PackageProjectUrl>https://github.com/qmfrederik/remoteviewing/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/qmfrederik/remoteviewing/blob/master/License.txt</PackageLicenseUrl>
     <PackageTags>VNC RFB remote desktop client server Hextile Copyrect Zlib</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <CodeAnalysisRuleSet>..\RemoteViewing.ruleset</CodeAnalysisRuleSet>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RemoteViewing/RemoteViewing.csproj
+++ b/RemoteViewing/RemoteViewing.csproj
@@ -12,12 +12,15 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Quamotion.RemoteViewing</PackageId>
     <PackageProjectUrl>https://github.com/qmfrederik/remoteviewing/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/qmfrederik/remoteviewing/blob/master/License.txt</PackageLicenseUrl>
     <PackageTags>VNC RFB remote desktop client server Hextile Copyrect Zlib</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <CodeAnalysisRuleSet>..\RemoteViewing.ruleset</CodeAnalysisRuleSet>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,3 +18,6 @@ on_success:
   - ps: Push-AppveyorArtifact "RemoteViewing\bin\Release\Quamotion.RemoteViewing.*.nupkg"
   - ps: Push-AppveyorArtifact "RemoteViewing.Windows.Forms\bin\Release\Quamotion.RemoteViewing.Windows.Forms.*.nupkg"
   - ps: Push-AppveyorArtifact "RemoteViewing.AspNetCore\bin\Release\Quamotion.RemoteViewing.AspNetCore.*.nupkg"
+  - ps: Push-AppveyorArtifact "RemoteViewing\bin\Release\Quamotion.RemoteViewing.*.snupkg"
+  - ps: Push-AppveyorArtifact "RemoteViewing.Windows.Forms\bin\Release\Quamotion.RemoteViewing.Windows.Forms.*.snupkg"
+  - ps: Push-AppveyorArtifact "RemoteViewing.AspNetCore\bin\Release\Quamotion.RemoteViewing.AspNetCore.*.snupkg"


### PR DESCRIPTION
Use the PackageLicenseExpression tag to set the license of the NuGet package. Also publish source packages.