### PR TITLE
Handle capture failures from the frame buffer source

### DIFF
--- a/RemoteViewing.Tests/VncServerSessionTests.cs
+++ b/RemoteViewing.Tests/VncServerSessionTests.cs
@@ -1,0 +1,45 @@
+using RemoteViewing.Vnc;
+using RemoteViewing.Vnc.Server;
+using System.IO;
+using System.Text;
+using Xunit;
+using Moq;
+
+namespace RemoteViewing.Tests
+{
+    public class VncServerSessionTests
+    {
+        [Fact]
+        public void FramebufferSendChangesTest()
+        {
+            var session = new VncServerSession();
+            var framebufferSourceMock = new Mock<IVncFramebufferSource>();
+            var framebuffer = new VncFramebuffer("My Framebuffer", width: 0x4f4, height: 0x3c1, pixelFormat: VncPixelFormat.RGB32);
+            framebufferSourceMock
+                .Setup(f => f.Capture())
+                .Returns(
+                () =>
+                {
+                    return framebuffer;
+                });
+            session.FramebufferUpdateRequest = new FramebufferUpdateRequest(false, new VncRectangle(0, 0, 100, 100));
+            session.SetFramebufferSource(framebufferSourceMock.Object);
+            session.FramebufferSendChanges();
+
+            Assert.Equal(framebuffer, session.Framebuffer);
+
+            framebufferSourceMock = new Mock<IVncFramebufferSource>();
+            framebufferSourceMock
+                .Setup(f => f.Capture())
+                .Throws(new IOException());
+
+            session.FramebufferUpdateRequest = new FramebufferUpdateRequest(false, new VncRectangle(0, 0, 100, 100));
+            session.SetFramebufferSource(framebufferSourceMock.Object);
+            
+            // should not throw and exception.
+            session.FramebufferSendChanges();
+
+            Assert.Equal(framebuffer, session.Framebuffer);
+        }
+    }
+}

--- a/RemoteViewing/Vnc/Server/VncServerSession.cs
+++ b/RemoteViewing/Vnc/Server/VncServerSession.cs
@@ -933,10 +933,17 @@ namespace RemoteViewing.Vnc.Server
                     var fbSource = this.fbSource;
                     if (fbSource != null)
                     {
-                        var newFramebuffer = fbSource.Capture();
-                        if (newFramebuffer != null && newFramebuffer != this.Framebuffer)
+                        try
                         {
-                            this.Framebuffer = newFramebuffer;
+                            var newFramebuffer = fbSource.Capture();
+                            if (newFramebuffer != null && newFramebuffer != this.Framebuffer)
+                            {
+                                this.Framebuffer = newFramebuffer;
+                            }
+                        }
+                        catch(Exception exc)
+                        {
+                            this.logger?.Log(LogLevel.Error, () => $"Capturing the framebuffer source failed: {exc}.");
                         }
                     }
 


### PR DESCRIPTION
It can happen that capturing the frame buffer source fails. This would currently stop syncing the screen.

This PR ignores failed captures.