### PR TITLE
Target netstandard2.1

### DIFF
--- a/RemoteViewing.AspNetCore/RemoteViewing.AspNetCore.csproj
+++ b/RemoteViewing.AspNetCore/RemoteViewing.AspNetCore.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>RemoteViewing - ASP.NET Core noVNC Server.</AssemblyTitle>
     <VersionPrefix>1.0.8</VersionPrefix>
     <Authors>James F. Bellinger, Frederik Carlier</Authors>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <AssemblyName>RemoteViewing.AspNetCore</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Quamotion.RemoteViewing.AspNetCore</PackageId>
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All"/>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.28" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/RemoteViewing.NoVncExample/RemoteViewing.NoVncExample.csproj
+++ b/RemoteViewing.NoVncExample/RemoteViewing.NoVncExample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <CodeAnalysisRuleSet>..\RemoteViewing.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   

--- a/RemoteViewing.NoVncExample/Startup.cs
+++ b/RemoteViewing.NoVncExample/Startup.cs
@@ -45,8 +45,6 @@ namespace RemoteViewing.NoVncExample
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
-            loggerFactory.AddConsole();
-
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/RemoteViewing.Windows.Forms/RemoteViewing.Windows.Forms.csproj
+++ b/RemoteViewing.Windows.Forms/RemoteViewing.Windows.Forms.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright © 2013 James F. Bellinger &lt;http://www.zer7.com/software/remoteviewing&gt;</Copyright>
     <VersionPrefix>1.0.8</VersionPrefix>
     <Authors>James F. Bellinger, Frederik Carlier</Authors>
-    <TargetFrameworks>net461;netstandard2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.1</TargetFrameworks>
     <AssemblyName>RemoteViewing.Windows.Forms</AssemblyName>
     <AssemblyOriginatorKeyFile>RemoteViewing.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -23,9 +23,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All"/>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.28" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
@@ -37,14 +37,12 @@
     <ProjectReference Include="..\RemoteViewing\RemoteViewing.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="System.Drawing.Common" Version="4.5.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Drawing.Common" Version="4.6.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Update="VncControl.cs">
-      <SubType>UserControl</SubType>
-    </Compile>
+    <Compile Update="VncControl.cs" />
     <Compile Update="VncControl.Designer.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/RemoteViewing.Windows.Forms/Server/VncScreenFramebufferSource.cs
+++ b/RemoteViewing.Windows.Forms/Server/VncScreenFramebufferSource.cs
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #endregion
 
-#if !NETSTANDARD2_0 && !NETCOREAPP2_1
+#if NET461
 using System;
 using System.Drawing;
 using System.Windows.Forms;

--- a/RemoteViewing.Windows.Forms/VncControl.Designer.cs
+++ b/RemoteViewing.Windows.Forms/VncControl.Designer.cs
@@ -1,6 +1,6 @@
 ﻿namespace RemoteViewing.Windows.Forms
 {
-#if !NETSTANDARD2_0 && !NETCOREAPP2_1
+#if NET461
     partial class VncControl
     {
         /// <summary> 

--- a/RemoteViewing.Windows.Forms/VncControl.cs
+++ b/RemoteViewing.Windows.Forms/VncControl.cs
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #endregion
 
-#if !NETSTANDARD2_0 && !NETCOREAPP2_1
+#if NET461
 using RemoteViewing.Vnc;
 using System;
 using System.Collections.Generic;

--- a/RemoteViewing.Windows.Forms/VncKeysym.cs
+++ b/RemoteViewing.Windows.Forms/VncKeysym.cs
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #endregion
 
-#if !NETSTANDARD2_0 && !NETCOREAPP2_1
+#if NET461
 using RemoteViewing.Vnc;
 using System;
 using System.Windows.Forms;

--- a/RemoteViewing/RemoteViewing.csproj
+++ b/RemoteViewing/RemoteViewing.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright © 2013 James F. Bellinger &lt;http://www.zer7.com/software/remoteviewing&gt;</Copyright>
     <VersionPrefix>1.0.8</VersionPrefix>
     <Authors>James F. Bellinger, Frederik Carlier</Authors>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.1</TargetFrameworks>
     <AssemblyName>RemoteViewing</AssemblyName>
     <AssemblyOriginatorKeyFile>RemoteViewing.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -25,17 +25,15 @@
 
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All"/>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
-
-    <PackageReference Include="System.Memory" Version="4.5.0" />
-    <PackageReference Include="System.Buffers" Version="4.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.28" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="Microsoft.CSharp" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 before_build:
   - cmd: choco install codecov


### PR DESCRIPTION
Remove dependencies which are not required on netstandard2.1 to simplify the dependency graph on .NET Core